### PR TITLE
Added support for public keys, change fingerprinting code

### DIFF
--- a/algorithms.js
+++ b/algorithms.js
@@ -61,7 +61,7 @@ var sigInfo = null;
 packets.splitPackets(key).forEachSeries(function(type, header, body, cb) {
 	if(keyInfo == null)
 	{
-		packetContent.getPublicKeyPacketInfo(body, function(err, info) {
+		packetContent.getKeyPacketInfo(type, body, function(err, info) {
 			keyInfo = info;
 			cb();
 		});

--- a/keyring/importExport.js
+++ b/keyring/importExport.js
@@ -146,6 +146,7 @@ utils.extend(Keyring.prototype, {
 
 					switch(tag) {
 						case consts.PKT.PUBLIC_KEY:
+						case consts.PKT.SECRET_KEY:
 							lastKeyImported = { type: tag, id: info.id, signatures: [ ], subkeys: [ ], identities: [ ], attributes: [ ] };
 							t.addKey(info, function(err) {
 								if(err)

--- a/keyring/signatureRelations.js
+++ b/keyring/signatureRelations.js
@@ -463,7 +463,7 @@ utils.extend(Keyring.prototype, {
 			if(err)
 				return callback(err);
 
-			packetContent.getPublicKeyPacketInfo(keyInfo.binary, function(err, keyInfoOrig) {
+			packetContent.getKeyPacketInfo(null, keyInfo.binary, function(err, keyInfoOrig) {
 				if(err)
 					return callback(err);
 

--- a/packetContent.js
+++ b/packetContent.js
@@ -97,11 +97,20 @@ function getKeyPacketInfo(tag, body, callback)
 			return callback(new Error("Unknown public key algorithm "+ret.pkalgo));
 
 		ret.key = body.slice(6, 6+keyParts.bytes);
-		
-		var fingerprintData = new Buffer(body.length + 3);
+
+		var bsize = keyParts.bytes + 6,
+			fingerprintData = new Buffer(bsize + 3);
+
 		fingerprintData.writeUInt8(0x99, 0);
-		fingerprintData.writeUInt16BE(body.length, 1);
-		body.copy(fingerprintData, 3);
+		fingerprintData.writeUInt16BE(bsize, 1);
+
+		// body
+		fingerprintData.writeUInt8(0x04, 3);
+		fingerprintData.writeUInt32BE(ret.date / 1000, 4)
+		fingerprintData.writeUInt8(ret.pkalgo, 8);
+
+		ret.key.copy(fingerprintData, 9);
+
 		ret.fingerprint = utils.hash(fingerprintData, "sha1", "hex").toUpperCase();
 		ret.id = ret.fingerprint.substring(ret.fingerprint.length-16);
 	}

--- a/packetContent.js
+++ b/packetContent.js
@@ -7,10 +7,12 @@ function getPacketInfo(tag, body, callback) {
 	switch(tag)
 	{
 		case consts.PKT.PUBLIC_KEY:
-			getPublicKeyPacketInfo(body, callback);
+		case consts.PKT.SECRET_KEY:
+			getKeyPacketInfo(tag, body, callback);
 			break;
 		case consts.PKT.PUBLIC_SUBKEY:
-			getPublicSubkeyPacketInfo(body, callback);
+		case consts.PKT.SECRET_SUBKEY:
+			getSubkeyPacketInfo(tag, body, callback);
 			break;
 		case consts.PKT.USER_ID:
 			getIdentityPacketInfo(body, callback);
@@ -26,10 +28,10 @@ function getPacketInfo(tag, body, callback) {
 	}
 }
 
-function getPublicKeyPacketInfo(body, callback)
+function getKeyPacketInfo(tag, body, callback)
 {
 	var ret = {
-		pkt: consts.PKT.PUBLIC_KEY,
+		pkt: tag,
 		id: null,
 		binary : body,
 		version : body.readUInt8(0),
@@ -120,9 +122,9 @@ function getPublicKeyPacketInfo(body, callback)
 	callback(null, ret);
 }
 
-function getPublicSubkeyPacketInfo(body, callback)
+function getSubkeyPacketInfo(pkt, body, callback)
 {
-	getPublicKeyPacketInfo(body, function(err, info) {
+	getKeyPacketInfo(pkt, body, function(err, info) {
 		if(err) { callback(err); return; }
 		
 		info.pkt = consts.PKT.PUBLIC_SUBKEY;
@@ -429,8 +431,8 @@ function getValueForSignatureSubPacket(type, binary) {
 }
 
 exports.getPacketInfo = getPacketInfo;
-exports.getPublicKeyPacketInfo = getPublicKeyPacketInfo;
-exports.getPublicSubkeyPacketInfo = getPublicSubkeyPacketInfo;
+exports.getKeyPacketInfo = getKeyPacketInfo;
+exports.getSubkeyPacketInfo = getSubkeyPacketInfo;
 exports.getAttributePacketInfo = getAttributePacketInfo;
 exports.getIdentityPacketInfo = getIdentityPacketInfo;
 exports.getSignaturePacketInfo = getSignaturePacketInfo;

--- a/tests/pgp.js
+++ b/tests/pgp.js
@@ -427,7 +427,7 @@ exports.key1 = function(test) {
 	}
 	
 	function end() {
-		pgp.packetContent.getPublicKeyPacketInfo(key, function(err, info) {
+		pgp.packetContent.getKeyPacketInfo(null, key, function(err, info) {
 			test.ifError(err);
 
 			test.equals(info.version, 4);


### PR DESCRIPTION
Hi,

I've added support for private keys to node-pgp. It basically employs the same methods that were being used for public keys.

I've also changed the fingerprinting code, since RFC 480 states that:

> A V4 fingerprint is the 160-bit SHA-1 hash of the octet 0x99, followed by the two-octet packet length, followed by the entire Public-Key packet starting with the version field."

This apparently means that, in the case of a private key packet, all additional content should be ignored. Right now, fingerprints are being calculated taking the full key content into account (probably because until now only public keys were allowed). So, this patch should change that.

Please let me know what you think. I am available for any changes/improvements!
